### PR TITLE
Fixes to calc_bytes unit detection

### DIFF
--- a/borg_exporter
+++ b/borg_exporter
@@ -27,7 +27,7 @@ function calc_bytes {
 	UNIT=$2
 	
 	case "$UNIT" in
-		KB)
+		kB)
 			echo $NUM | awk '{ print $1 * 1024 }'
 			;;
 		MB)
@@ -35,6 +35,9 @@ function calc_bytes {
 			;;
 		GB)
 			echo $NUM | awk '{ print $1 * 1024 * 1024 * 1024 }'
+			;;
+		TB)
+			echo $NUM | awk '{ print $1 * 1024 * 1024 * 1024 * 1024 }'
 			;;
 	esac
 }


### PR DESCRIPTION
This PR fixes the parsing of units from "borg info" output.

Especially:
- borg info outputs "kB" for kilobytes, instead of "KB"
- there was not code to handle the "TB" for terabytes.

Sample trimmed output from my borg backups (using borg v1.0.9).

Featuring the "kB" unit:
```
                       Original size      Compressed size    Deduplicated size
This archive:               26.40 kB             24.16 kB              1.41 kB
All archives:               52.81 kB             48.31 kB             25.57 kB

                       Unique chunks         Total chunks
Chunk index:                      12                   20
```

Featuring the "TB" unit:
```
                       Original size      Compressed size    Deduplicated size
This archive:              216.15 GB            201.13 GB            268.56 MB
All archives:                4.31 TB              4.01 TB             53.11 GB

                       Unique chunks         Total chunks
Chunk index:                  124472              3979119
```