### PR TITLE
Provide textfile collector directory via env file

### DIFF
--- a/borg.env
+++ b/borg.env
@@ -1,2 +1,3 @@
 BORG_PASSPHRASE=<your-passphrase>
 REPOSITORY=<your-repository>
+COLLECTOR_DIR=</var/lib/node_exporter/textfile_collector>

--- a/borg_exporter
+++ b/borg_exporter
@@ -4,7 +4,7 @@ set -eu
 
 source /etc/borg
 
-TEXTFILE_COLLECTOR_DIR=/var/lib/node_exporter/textfile_collector
+TEXTFILE_COLLECTOR_DIR=${COLLECTOR_DIR:-/var/lib/node_exporter/textfile_collector}
 PROM_FILE=$TEXTFILE_COLLECTOR_DIR/backup.prom
 TMP_FILE=$PROM_FILE.$$
 HOSTNAME=$(hostname)

--- a/borg_exporter
+++ b/borg_exporter
@@ -14,7 +14,7 @@ COUNTER=0
 mkdir -p $TEXTFILE_COLLECTOR_DIR
 
 for i in $LIST; do
-	COUNTER=$((COUNTER+1))
+  COUNTER=$((COUNTER+1))
 done
 
 BORG_INFO=$(BORG_PASSPHRASE=$BORG_PASSPHRASE borg info "$REPOSITORY::$i")
@@ -24,23 +24,23 @@ echo "backup_chunks_unique{host=\"${HOSTNAME}\"} $(echo "$BORG_INFO" | grep "Chu
 echo "backup_chunks_total{host=\"${HOSTNAME}\"} $(echo "$BORG_INFO" | grep "Chunk index" | awk '{print $4}')" >> $TMP_FILE
 
 function calc_bytes {
-	NUM=$1
-	UNIT=$2
-	
-	case "$UNIT" in
-		kB)
-			echo $NUM | awk '{ print $1 * 1024 }'
-			;;
-		MB)
-			echo $NUM | awk '{ print $1 * 1024 * 1024 }'
-			;;
-		GB)
-			echo $NUM | awk '{ print $1 * 1024 * 1024 * 1024 }'
-			;;
-		TB)
-			echo $NUM | awk '{ print $1 * 1024 * 1024 * 1024 * 1024 }'
-			;;
-	esac
+  NUM=$1
+  UNIT=$2
+  
+  case "$UNIT" in
+    kB)
+      echo $NUM | awk '{ print $1 * 1024 }'
+      ;;
+    MB)
+      echo $NUM | awk '{ print $1 * 1024 * 1024 }'
+      ;;
+    GB)
+      echo $NUM | awk '{ print $1 * 1024 * 1024 * 1024 }'
+      ;;
+    TB)
+      echo $NUM | awk '{ print $1 * 1024 * 1024 * 1024 * 1024 }'
+      ;;
+  esac
 }
 
 # byte size

--- a/borg_exporter
+++ b/borg_exporter
@@ -26,7 +26,7 @@ echo "backup_chunks_total{host=\"${HOSTNAME}\"} $(echo "$BORG_INFO" | grep "Chun
 function calc_bytes {
   NUM=$1
   UNIT=$2
-  
+
   case "$UNIT" in
     kB)
       echo $NUM | awk '{ print $1 * 1024 }'


### PR DESCRIPTION
Hi,
the prometheus node_exporter can only handle a single directory for textfile collection. I'm already using a different path and wanted a solution to set it, if desired. You can now set COLLECTOR_DIR in the env file, if it is unset it uses the old path as fallback.