### PR TITLE
fix borg backup now timestamp as space in now will cause an error in …

### DIFF
--- a/borg_exporter
+++ b/borg_exporter
@@ -8,12 +8,13 @@ TEXTFILE_COLLECTOR_DIR=${COLLECTOR_DIR:-/var/lib/node_exporter/textfile_collecto
 PROM_FILE=$TEXTFILE_COLLECTOR_DIR/backup.prom
 TMP_FILE=$PROM_FILE.$$
 HOSTNAME=$(hostname)
-LIST=$(BORG_PASSPHRASE=$BORG_PASSPHRASE borg list $REPOSITORY |awk '{print $1}')
+LIST=$(BORG_PASSPHRASE=$BORG_PASSPHRASE borg list $REPOSITORY |awk '{print $1, $2}')
 COUNTER=0
 
 mkdir -p $TEXTFILE_COLLECTOR_DIR
 
-for i in $LIST; do
+IFS=$'\n'
+for i in ${LIST[@]}; do
   COUNTER=$((COUNTER+1))
 done
 


### PR DESCRIPTION
When borg backup run with default timestamp now it contains space in timestamp like example

`The {now} gives value as this 2021-01-31 02:03:17.384699`

So for loop list in borg exporter it treats space as another value and try to itreate through date and time differently as we are using awk {'print $1'} in list

So to support borg default now timestamp by this exporter script changed script to support now in borg